### PR TITLE
Feature/hide config contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ You can get config file from your k8s master node `.kube/config`.
 See [Microsoft Azure Container Service Engine - Kubernetes Walkthrough](https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough)
 Then copy the file content and paste on kubeconfig column.
 
+**NOTE**  
+
+If you copy config file into Kubeconfig, the build log of VSTS might show you the contents.
+This happens when you copy multiline. 
+Kubernetes tasks support base64 encoding for Kubeconfig column. If you want to avoid this problem,
+you can convert your config file into base64 string. You can find the tool for converting config file. `tools/convert.ts`
+
+**Usage**
+
+your config file should be `LF` not `CRLF` if you want to use on Linux hosted build.
+
+```
+tsc -p .
+node tools/convert.js {filename}
+```
+
+You can find {filename}_new file which include base64 encoding string.
+
+
 ## 5.2. Store and link kubectl command link with VSTS private repository
 
 Link your repo which has kubecntl command. 
@@ -102,7 +121,6 @@ You can use every kubectl command you want. Use kubectlgeneral task.
 You can specify a lot of arguments separated with space or new line. 
 
 ![kubectlgeneral Task](https://raw.githubusercontent.com/TsuyoshiUshio/KubernetesTask/master/docs/images/general.png)
-
 
 # 6 Resources
 

--- a/Tests/L1.ts
+++ b/Tests/L1.ts
@@ -63,4 +63,36 @@ describe('General Task', function () {
         expect(tr.ran("./Tests/kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x --kubeconfig ./config")).to.be.true;
         done();
     });
+
+    it("make sure the file is written collectly", (done: MochaDone) => {
+        let tp = path.join(__dirname, 'test-general-base64.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+        let contents: string = fs.readFileSync(config_file_path, 'utf8');
+        let result : string = 
+`
+---
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: "XXXXXXXXXXXXXXXX"
+    server: https://xxxxxxxxmgmt.japanwest.cloudapp.azure.com
+  name: "xxxxxxxxmgmt"
+contexts:
+- context:
+    cluster: "xxxxxxxxmgmt"
+    user: "xxxxxxxxmgmt-admin"
+  name: "xxxxxxxxmgmt"
+current-context: "xxxxxxxxmgmt"
+kind: Config
+users:
+- name: "xxxxxxxxmgmt-admin"
+  user:
+    client-certificate-data: "XXXXXXXXXX"
+    client-key-data: "XXXXXXXXXXXXXXXXXX"
+
+`;
+        expect(contents).to.equal(result);
+        done();
+    });
 });

--- a/Tests/test-general-base64.ts
+++ b/Tests/test-general-base64.ts
@@ -1,0 +1,34 @@
+/// <reference path="../typings/globals/node/index.d.ts" />
+
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'general.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('kubectlBinary', './Tests/kubectl');
+tr.setInput('k8sService', 'k8sendpoint');
+tr.setInput('subCommand', 'expose');
+tr.setInput('arguments', 'deployment echoheaders\n--port=80\n--target-port=8080\n--name=echoheaders-x');
+
+
+process.env['ENDPOINT_AUTH_PARAMETER_K8SENDPOINT_KUBECONFIG'] = `Ci0tLQphcGlWZXJzaW9uOiB2MQpjbHVzdGVyczoKLSBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6ICJYWFhYWFhYWFhYWFhYWFhYIgogICAgc2VydmVyOiBodHRwczovL3h4eHh4eHh4bWdtdC5qYXBhbndlc3QuY2xvdWRhcHAuYXp1cmUuY29tCiAgbmFtZTogInh4eHh4eHh4bWdtdCIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ4eHh4eHh4eG1nbXQiCiAgICB1c2VyOiAieHh4eHh4eHhtZ210LWFkbWluIgogIG5hbWU6ICJ4eHh4eHh4eG1nbXQiCmN1cnJlbnQtY29udGV4dDogInh4eHh4eHh4bWdtdCIKa2luZDogQ29uZmlnCnVzZXJzOgotIG5hbWU6ICJ4eHh4eHh4eG1nbXQtYWRtaW4iCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZS1kYXRhOiAiWFhYWFhYWFhYWCIKICAgIGNsaWVudC1rZXktZGF0YTogIlhYWFhYWFhYWFhYWFhYWFhYWCIKCg==`;
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "checkPath": {
+        "./Tests/kubectl": true
+    },
+    "cwd": {
+        "cwd": process.cwd(),
+    },
+    "exec": {
+       "./Tests/kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x --kubeconfig ./config": {
+          "code": 0,
+          "stdout": "echoheader exposed."  
+       }
+   } 
+}
+tr.setAnswers(a);
+
+tr.run();

--- a/kubectl.ts
+++ b/kubectl.ts
@@ -14,9 +14,21 @@ export class KubectlCommand {
     configfile: string;
     kubectl: ToolRunner;
 
+    isBase64(contents) {
+    let base64Regx = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/
+    return base64Regx.test(contents);
+    }
+
+    decodeBase64(contents) {
+        return new Buffer(contents, 'base64').toString();
+    }
+
     constructor() {
         this.endpoint = tl.getInput('k8sService');
         this.kubeconfig = tl.getEndpointAuthorizationParameter(this.endpoint, 'kubeconfig', true);
+        if (this.isBase64(this.kubeconfig)) {
+            this.kubeconfig = this.decodeBase64(this.kubeconfig);
+        }   
         this.kubectlbinary = tl.getInput('kubectlBinary');
         this.configfile = path.join(tl.cwd(), "config");
         this.kubectl = tl.tool(this.kubectlbinary);

--- a/tools/convert.ts
+++ b/tools/convert.ts
@@ -1,0 +1,29 @@
+/// <reference path="../typings/globals/node/index.d.ts" />
+
+import fs = require('fs');
+import path = require('path');
+
+function isBase64(content){
+    let base64Regx = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/
+    return base64Regx.test(content);
+}
+
+async function run() {
+    let filename = 'config';
+    if (process.argv.length === 3) {
+        filename = process.argv[2];
+    }
+    let content  = fs.readFileSync(filename);
+    let newContent: string = new Buffer(content).toString('base64');
+    let filePath = path.join(process.cwd(), filename + "_new");
+    await fs.writeFile(filePath, newContent, (x) => {});
+    let decoded :string = new Buffer(newContent, 'base64').toString();
+    filePath = path.join(process.cwd(), filename + "_decode");
+    await fs.writeFile(filePath, decoded, (x) => {} );
+
+    let result = isBase64(content) + ":" + isBase64(newContent);
+    filePath = path.join(process.cwd(), "result.txt");
+    await fs.writeFile(filePath, result, (x) => {});
+    
+}
+run();


### PR DESCRIPTION
https://github.com/TsuyoshiUshio/KubernetesTask/projects/1#card-1688957

Currently, If you copy & paste your config file into the kubeconfig of the endpoint, VSTS output the contents while the build execute. It seems that it is because it is multiline. 

That is why I support base64 string of config file. If you convert your config file into base64 and copy and paste on the kubeconfig of the endpoint, it is automatically decoded into config file.  