### PR TITLE
Add null check for arguments

### DIFF
--- a/general.ts
+++ b/general.ts
@@ -15,8 +15,10 @@ kubectl.init().then(
     function() {
         kubectl.append(subCommand);
 
-        multilineArgs.split(/\s+/).map(function (x) { kubectl.append(x) });
-
+        if (multilineArgs) {
+            multilineArgs.split(/\s+/).map(function (x) { kubectl.append(x) });
+        }
+        
         kubectl.exec();
     }
 );


### PR DESCRIPTION
If "Arguments" field in General task is empty, task produces an error: `Cannot read property 'split' of null`.