### PR TITLE
Fix: ConfigFile not found

### DIFF
--- a/kubectl.ts
+++ b/kubectl.ts
@@ -42,6 +42,11 @@ export class KubectlCommand {
         this.execCommand();
     }
     async init() {
+        tl.debug("cwd(): " + tl.cwd());
+        tl.debug("configfile: " + this.configfile);
+        fs.writeFileSync(this.configfile, this.kubeconfig);
+
+
         if (this.kubectlbinary === tl.cwd()) {
             this.kubectlbinary = await this.downloadKubectl(this.downloadVersion);
         }
@@ -81,12 +86,8 @@ export class KubectlCommand {
     }
 
     async execCommand() {
-        try {                     
-             tl.debug("cwd(): " + tl.cwd());
-             tl.debug("configfile: " + this.configfile);
-             await fs.writeFile(this.configfile, this.kubeconfig);
-             this.kubectl.arg('--kubeconfig').arg(this.configfile);
-
+        try {       
+             this.kubectl.arg('--kubeconfig').arg(this.configfile);              
              tl.debug("settings kubectl exec perms");
              tl.checkPath(this.kubectlbinary, 'kubectlBinary');
              tl.checkPath(this.configfile, 'configFile');

--- a/tasks/apply/task.json
+++ b/tasks/apply/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "2",
     "Minor": "0",
-    "Patch": "0"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "kubectlapply $(message)",

--- a/tasks/general/task.json
+++ b/tasks/general/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": "2",
     "Minor": "0",
-    "Patch": "0"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "kubectlgeneral $(message)",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
 "manifestVersion": 1,
   "id": "k8s-endpoint",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "name": "Kubernetes extension",
   "description": "Kubernetes extension with k8s endpoint. Which enable kubectl command",
   "publisher": "TsuyoshiUshio",


### PR DESCRIPTION
The error only happens when I use kube apply task without downloading
kubectl. The error happnens at varidation of
tl.checkPath(this.configfile, 'configfile'); after the kubectl apply
task, I check if these is .kubeconfig or not. It exists.

I guess the problem is asyncronous related problem. That is why, I move
the sesion of the writing .kubeconfig file and make it Sync method.
Now it works.