### PR TITLE
Linking kubectl

### DIFF
--- a/kubectl.ts
+++ b/kubectl.ts
@@ -90,6 +90,11 @@ export class KubectlCommand {
                 await chmod.exec();            
             }
 
+            tl.debug("Linking this version of kubectl");
+            let ln: ToolRunner = tl.tool("ln");
+            ln.arg("-s").arg(kubectlBinary).arg("/usr/bin/kubectl");
+            await ln.exec();
+
             tl.debug(`using [${kubectlBinary}]`);
             return kubectlBinary;
         } catch (err) {


### PR DESCRIPTION
Hey @TsuyoshiUshio I'm trying to add the capability to create a symbolic link to whatever version of kubectl is in use.

For some reason the `ln.exec()` command fails and the test doesn't pass. Do you have any idea why that is the case?