### PR TITLE
Adding a feature to check the OSType.

### DIFF
--- a/Tests/L0.ts
+++ b/Tests/L0.ts
@@ -57,4 +57,25 @@ describe('Kubectl apply Task', function () {
         expect(tr.ran("./Tests/kubectl apply -f ./Tests/my-nginx.yml --kubeconfig ./kubeconfig")).to.be.true;
         done();
     });
+
+    it("success when a user use hosted agent(linux)", (done: MochaDone) => {
+        process.env['Agent.OS'] = 'linux'
+        let tp = path.join(__dirname, 'test-apply.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+        expect(tr.stderr.length, 0);
+        done();
+    }); 
+
+    it("fails when a user use hosted agent(windows)", (done: MochaDone) => {
+        process.env['Agent.OS'] = undefined
+        let tp = path.join(__dirname, 'test-apply-oscheck.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+        expect(tr.stderr.length).to.not.equal(0);
+        tl.debug(tr.stderr.length.toString());
+        tl.debug(tr.stderr);
+        expect(tr.stderr).to.match(/.*This task does not work for Windows agent\./);
+        done();
+    }); 
 });

--- a/Tests/L1.ts
+++ b/Tests/L1.ts
@@ -23,7 +23,6 @@ function isExistFile(file) {
 
 describe('General Task', function () {
     before(() => {
-
         fs.unlink(config_file_path, function (err) {
             if (err) tl.debug("config not found (It's OK.)");
         });

--- a/Tests/test-apply-oscheck.ts
+++ b/Tests/test-apply-oscheck.ts
@@ -4,13 +4,13 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 
-let taskPath = path.join(__dirname, '..', 'general.js');
+let taskPath = path.join(__dirname, '..', 'apply.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-tr.setInput('kubectlBinary', process.cwd());
+tr.setInput('yamlfile', './Tests/my-nginx.yml');
+tr.setInput('kubectlBinary', './Tests/kubectl');
 tr.setInput('k8sService', 'k8sendpoint');
-tr.setInput('subCommand', 'get');
-tr.setInput('arguments', 'nodes');
+tr.setInput('system.debug', 'true');
 
 process.env['ENDPOINT_AUTH_PARAMETER_K8SENDPOINT_KUBECONFIG'] = `
 
@@ -38,35 +38,26 @@ users:
 `;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "which": {
+        "echo":  "/usr/bin/echo"
+    },
     "checkPath": {
         "./Tests/my-nginx.yml": true,
-        "/usr/bin/kubectl.vSomeVersion": true,
+        "./Tests/kubectl": true,
         "./kubeconfig": true
     },
     "cwd": {
         "cwd": process.cwd(),
     },
     "osType": {
-        "osType": "Linux",
+        "osType": "Windows_NT",
     },
     "exec": {
-       "/usr/bin/kubectl.vSomeVersion get nodes --kubeconfig ./kubeconfig": {
+       "./Tests/kubectl apply -f ./Tests/my-nginx.yml --kubeconfig ./kubeconfig": {
           "code": 0,
-          "stdout": "NAME                    STATUS                     AGE\nk8s-agent-559ac24b-0    Ready                      28d\nk8s-master-559ac24b-0   Ready,SchedulingDisabled   28d"  
-       },
-        "curl -L https://storage.googleapis.com/kubernetes-release/release/stable.txt": {
-          "code": 0,
-          "stdout": "vSomeVersion"  
-       },
-        "curl -L -o /usr/bin/kubectl.vSomeVersion https://storage.googleapis.com/kubernetes-release/release/vSomeVersion/bin/linux/amd64/kubectl": {
-          "code": 0,
-          "stdout": ""  
-       },
-        "chmod 777 /usr/bin/kubectl.vSomeVersion": {
-          "code": 0,
-          "stdout": ""  
+          "stdout": "deployment \"nginx-deployment\" created"  
        }
-    } 
+   } 
 }
 tr.setAnswers(a);
 

--- a/Tests/test-apply.ts
+++ b/Tests/test-apply.ts
@@ -49,6 +49,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "cwd": {
         "cwd": process.cwd(),
     },
+    "osType": {
+        "osType": "Linux",
+    },
     "exec": {
        "./Tests/kubectl apply -f ./Tests/my-nginx.yml --kubeconfig ./kubeconfig": {
           "code": 0,

--- a/Tests/test-general-base64.ts
+++ b/Tests/test-general-base64.ts
@@ -23,6 +23,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "cwd": {
         "cwd": process.cwd(),
     },
+    "osType": {
+        "osType": "Linux",
+    },
     "exec": {
        "./Tests/kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x --kubeconfig ./config": {
           "code": 0,

--- a/Tests/test-general-doubleminus.ts
+++ b/Tests/test-general-doubleminus.ts
@@ -45,6 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "cwd": {
         "cwd": process.cwd(),
     },
+    "osType": {
+        "osType": "Linux",
+    },
     "exec": {
        "./Tests/kubectl exec mongo-2180634381-zx0d3 --namespace mrp --kubeconfig ./kubeconfig -- mongo ordering /tmp/MongoRecords.js": {
           "code": 0,

--- a/Tests/test-general-expose.ts
+++ b/Tests/test-general-expose.ts
@@ -45,6 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     },
     "cwd": {
         "cwd": process.cwd(),
+    },    
+    "osType": {
+        "osType": "Linux",
     },
     "exec": {
        "./Tests/kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x --kubeconfig ./config": {

--- a/Tests/test-general.ts
+++ b/Tests/test-general.ts
@@ -46,6 +46,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "cwd": {
         "cwd": process.cwd(),
     },
+    "osType": {
+        "osType": "Linux",
+    },
     "exec": {
        "./Tests/kubectl get nodes --kubeconfig ./kubeconfig": {
           "code": 0,


### PR DESCRIPTION
I add a feature for checking os. It reject only for windows based agent.
A lot of people, didn't notice they use Windows Hosted agent. However,
it doesn't work for the new download feature.

We have three choice for implementations. One is tl.osType(), Second is
the process.env['Agent.OS'], and thrid is os.Type(). We can't use
os.Type() some people use windows for developing this task. We need to
mock them. that is why I choose tl.osType(). Also, ['Agent.OS'] is set
only when it is linux hotesd agent (preview). It is unreliable.