### PR TITLE
Fix: Changing the direcotry for kubectl binary

### DIFF
--- a/Tests/L1.ts
+++ b/Tests/L1.ts
@@ -38,7 +38,7 @@ describe('General Task', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
         tl.debug(tr.cmdlines);
-        expect(tr.ran("/usr/bin/kubectl.vSomeVersion get nodes --kubeconfig ./kubeconfig")).to.be.true;
+        expect(tr.ran("/opt/vsts/work/r1/a/kubectl.vSomeVersion get nodes --kubeconfig ./kubeconfig")).to.be.true;
         done();
     });
 

--- a/Tests/test-general-download.ts
+++ b/Tests/test-general-download.ts
@@ -12,6 +12,7 @@ tr.setInput('k8sService', 'k8sendpoint');
 tr.setInput('subCommand', 'get');
 tr.setInput('arguments', 'nodes');
 
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = '/opt/vsts/work/r1/a'
 process.env['ENDPOINT_AUTH_PARAMETER_K8SENDPOINT_KUBECONFIG'] = `
 
 ---
@@ -40,14 +41,14 @@ users:
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "checkPath": {
         "./Tests/my-nginx.yml": true,
-        "/usr/bin/kubectl.vSomeVersion": true,
+        "/opt/vsts/work/r1/a/kubectl.vSomeVersion": true,
         "./kubeconfig": true
     },
     "cwd": {
         "cwd": process.cwd(),
     },
     "exec": {
-       "/usr/bin/kubectl.vSomeVersion get nodes --kubeconfig ./kubeconfig": {
+       "/opt/vsts/work/r1/a/kubectl.vSomeVersion get nodes --kubeconfig ./kubeconfig": {
           "code": 0,
           "stdout": "NAME                    STATUS                     AGE\nk8s-agent-559ac24b-0    Ready                      28d\nk8s-master-559ac24b-0   Ready,SchedulingDisabled   28d"  
        },
@@ -55,11 +56,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
           "code": 0,
           "stdout": "vSomeVersion"  
        },
-        "curl -L -o /usr/bin/kubectl.vSomeVersion https://storage.googleapis.com/kubernetes-release/release/vSomeVersion/bin/linux/amd64/kubectl": {
+        "curl -L -o /opt/vsts/work/r1/a/kubectl.vSomeVersion https://storage.googleapis.com/kubernetes-release/release/vSomeVersion/bin/linux/amd64/kubectl": {
           "code": 0,
           "stdout": ""  
        },
-        "chmod 777 /usr/bin/kubectl.vSomeVersion": {
+        "chmod 777 /opt/vsts/work/r1/a/kubectl.vSomeVersion": {
           "code": 0,
           "stdout": ""  
        }

--- a/kubectl.ts
+++ b/kubectl.ts
@@ -76,8 +76,8 @@ export class KubectlCommand {
                 let result = curl.execSync();
                 downloadVersion = result.stdout.toString().trim();
             }
-
-            let kubectlBinary = `/usr/bin/kubectl.${downloadVersion}`;
+            let kubectlBinaryDir = process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'];
+            let kubectlBinary = kubectlBinaryDir + `/kubectl.${downloadVersion}`;
             if (!fs.exists(kubectlBinary)) {
                 tl.debug(`downloading kubectl [${kubectlBinary}]`);
                 let curl: ToolRunner = tl.tool("curl");


### PR DESCRIPTION
Kubectl binary was downloaded /usr/bin However, it works for hosted
agent linux. But a lot of Linux build agent machine won't have
permission for the directory. I change the directory into the
SYSTEM_DEFAULTWORKINGDIRECTORY.